### PR TITLE
Added noRecompute option to import reducer

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -65,8 +65,8 @@ export const ActionCreators = {
     return { type: ActionTypes.JUMP_TO_STATE, index };
   },
 
-  importState(nextLiftedState) {
-    return { type: ActionTypes.IMPORT_STATE, nextLiftedState };
+  importState(nextLiftedState, noRecompute) {
+    return { type: ActionTypes.IMPORT_STATE, nextLiftedState, noRecompute };
   }
 };
 
@@ -327,8 +327,8 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           computedStates
         } = liftedAction.nextLiftedState);
 
-        if(liftedAction.noRecompute){
-          minInvalidatedStateIndex = Inifinity
+        if (liftedAction.noRecompute) {
+          minInvalidatedStateIndex = Infinity;
         }
         break;
       }

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -326,6 +326,10 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           currentStateIndex,
           computedStates
         } = liftedAction.nextLiftedState);
+
+        if(liftedAction.noRecompute){
+          minInvalidatedStateIndex = Inifinity
+        }
         break;
       }
       case '@@redux/INIT': {

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -118,8 +118,9 @@ function recomputeStates(
   // Optimization: exit early and return the same reference
   // if we know nothing could have changed.
   if (
-    minInvalidatedStateIndex >= computedStates.length &&
-    computedStates.length === stagedActionIds.length
+    !computedStates ||
+    (minInvalidatedStateIndex >= computedStates.length &&
+    computedStates.length === stagedActionIds.length)
   ) {
     return computedStates;
   }

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -552,6 +552,14 @@ describe('instrument', () => {
       importMonitoredLiftedStore.dispatch(ActionCreators.importState(exportedState));
       expect(importMonitoredLiftedStore.getState()).toEqual(exportedState);
     });
+
+    it('should allow for state to be imported without replaying actions', () => {
+      let importMonitoredStore = createStore(counter, instrument());
+      let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
+
+      importMonitoredLiftedStore.dispatch(ActionCreators.importState(exportedState, true));
+      expect(importMonitoredLiftedStore.getState()).toEqual(exportedState);
+    });
   });
 
   it('throws if reducer is not a function', () => {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -557,8 +557,15 @@ describe('instrument', () => {
       let importMonitoredStore = createStore(counter, instrument());
       let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
 
-      importMonitoredLiftedStore.dispatch(ActionCreators.importState(exportedState, true));
-      expect(importMonitoredLiftedStore.getState()).toEqual(exportedState);
+      let noComputedExportedState = Object.assign({}, exportedState);
+      delete noComputedExportedState.computedStates;
+
+      importMonitoredLiftedStore.dispatch(ActionCreators.importState(noComputedExportedState, true));
+
+      let expectedImportedState = Object.assign({}, noComputedExportedState, {
+        computedStates: undefined
+      });
+      expect(importMonitoredLiftedStore.getState()).toEqual(expectedImportedState);
     });
   });
 


### PR DESCRIPTION
This option allows state to be imported without recomputing each action along the way.