### PR TITLE
import action array

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -322,21 +322,39 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
         break;
       }
       case ActionTypes.IMPORT_STATE: {
-        // Completely replace everything.
-        ({
-          monitorState,
-          actionsById,
-          nextActionId,
-          stagedActionIds,
-          skippedActionIds,
-          committedState,
-          currentStateIndex,
-          computedStates
-        } = liftedAction.nextLiftedState);
+        if (Array.isArray(liftedAction.nextLiftedState)) {
+          // recompute array of actions
+          actionsById = { 0: liftAction(INIT_ACTION) };
+          nextActionId = 1;
+          stagedActionIds = [0];
+          skippedActionIds = [];
+          currentStateIndex = liftedAction.nextLiftedState.length;
+          computedStates = [];
+          minInvalidatedStateIndex = 0;
+          // iterate through actions
+          liftedAction.nextLiftedState.forEach(action => {
+            actionsById[nextActionId] = liftAction(action);
+            stagedActionIds.push(nextActionId);
+            nextActionId++;
+          });
+        } else {
+          // Completely replace everything.
+          ({
+            monitorState,
+            actionsById,
+            nextActionId,
+            stagedActionIds,
+            skippedActionIds,
+            committedState,
+            currentStateIndex,
+            computedStates
+          } = liftedAction.nextLiftedState);
 
-        if (liftedAction.noRecompute) {
-          minInvalidatedStateIndex = Infinity;
+          if (liftedAction.noRecompute) {
+            minInvalidatedStateIndex = Infinity;
+          }
         }
+
         break;
       }
       case '@@redux/INIT': {


### PR DESCRIPTION
https://github.com/zalmoxisus/redux-devtools-extension/issues/173#issuecomment-236831433

tests arent working yet :(

```
  1) instrument Import Actions should replay all the steps when a state is imported:
     TypeError: Cannot read property 'type' of undefined
      at counter (instrument.spec.js:9:11)
      at computeNextEntry (instrument.js:80:21)
      at recomputeStates (instrument.js:145:17)
      at instrument.js:394:22
      at Object.dispatch (node_modules/redux/lib/createStore.js:179:22)
      at Context.<anonymous> (instrument.spec.js:613:34)

  2) instrument Import Actions should replace the existing action log with the one imported:
     TypeError: Cannot read property 'type' of undefined
      at counter (instrument.spec.js:9:11)
      at computeNextEntry (instrument.js:80:21)
      at recomputeStates (instrument.js:145:17)
      at instrument.js:394:22
      at Object.dispatch (node_modules/redux/lib/createStore.js:179:22)
      at Context.<anonymous> (instrument.spec.js:624:34)
```