### PR TITLE
Lock changes

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -312,8 +312,7 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
       }
       case ActionTypes.PERFORM_ACTION: {
         if (dropNewActions) {
-          minInvalidatedStateIndex = Infinity;
-          break;
+          return liftedState || initialLiftedState;
         }
 
         // Auto-commit as new actions come in.

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -635,6 +635,33 @@ describe('instrument', () => {
     });
   });
 
+  describe('Lock Changes', () => {
+    it('should lock', () => {
+      store.dispatch({ type: 'INCREMENT' });
+      store.liftedStore.dispatch({ type: 'LOCK_CHANGES', status: true });
+      expect(store.liftedStore.getState().dropNewActions).toBe(true);
+      expect(store.liftedStore.getState().nextActionId).toBe(2);
+      expect(store.getState()).toBe(1);
+
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.liftedStore.getState().nextActionId).toBe(2);
+      expect(store.getState()).toBe(1);
+
+      liftedStore.dispatch(ActionCreators.toggleAction(1));
+      expect(store.getState()).toBe(0);
+      liftedStore.dispatch(ActionCreators.toggleAction(1));
+      expect(store.getState()).toBe(1);
+
+      store.liftedStore.dispatch({ type: 'LOCK_CHANGES', status: false });
+      expect(store.liftedStore.getState().dropNewActions).toBe(false);
+      expect(store.liftedStore.getState().nextActionId).toBe(2);
+
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.liftedStore.getState().nextActionId).toBe(3);
+      expect(store.getState()).toBe(2);
+    });
+  });
+
   it('throws if reducer is not a function', () => {
     expect(() =>
       createStore(undefined, instrument())


### PR DESCRIPTION
It allows to ignore any other future actions in the app, not to mess up the state while working on a feature. We'll be able to have the “loop mode” described by @gaearon in https://twitter.com/dan_abramov/status/761549682178916352.

The "Record" button would call `commit()` and “Stop” is intended to have the behaviour of `lockChanges(true)`. Then to exit the “loop mode”, call `lockChanges(false)`.