### PR TITLE
Detect Electron in addition to Chrome

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -86,7 +86,12 @@ function computeNextEntry(reducer, action, state, shouldCatchErrors) {
     nextState = reducer(state, action);
   } catch (err) {
     nextError = err.toString();
-    if (typeof window === 'object' && typeof window.chrome !== 'undefined') {
+    if (
+      typeof window === 'object' && (
+      typeof window.chrome !== 'undefined' ||
+      typeof window.process !== 'undefined' &&
+      window.process.type === 'renderer'
+    )) {
       // In Chrome, rethrowing provides better source map support
       setTimeout(() => { throw err; });
     } else {


### PR DESCRIPTION
When a reducer causes an error, the error is logged with `console.error(err)`, in most browsers, however in Chrome the error is rethrown. Since the Electron Renderer behaves like Chrome in this regard, I believe it would be a good idea to detect it as well.