### PR TITLE
Prevent recomputing the states on hot reloading (or on replacing the reducers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export default function configureStore(initialState) {
   - **options** *object*
     - **maxAge** *number* - maximum allowed actions to be stored on the history tree, the oldest actions are removed once `maxAge` is reached. 
     - **shouldCatchErrors** *boolean* - if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
+    - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
 
 ### License
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -380,7 +380,11 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
         break;
       }
       case '@@redux/INIT': {
-        // Always recompute states on hot reload and init.
+        if (options.shouldHotReload === false && liftedState) {
+          return liftedState;
+        }
+
+        // Recompute states on hot reload and init.
         minInvalidatedStateIndex = 0;
 
         if (options.maxAge && stagedActionIds.length > options.maxAge) {


### PR DESCRIPTION
The PR introduces a new optional parameter `shouldHotReload` in order to disable recomputing states on hot reloading, which is a problem for some use cases which invokes `replaceReducer` like https://github.com/gaearon/redux-devtools/issues/304 and https://github.com/zalmoxisus/redux-devtools-extension/issues/205.

We could handle hot reloading (`module.hot`) and replace reducers right from the instrumentation, then there will be no need to watch `@@redux/INIT`, but it would be a breaking change, which better to address in `2.0`.