### PR TITLE
Start / pause recording the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export default function configureStore(initialState) {
   - **options** *object*
     - **maxAge** *number* - maximum allowed actions to be stored on the history tree, the oldest actions are removed once `maxAge` is reached. 
     - **shouldCatchErrors** *boolean* - if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
+    - **shouldRecordChanges** *boolean* - if specified as `false`, it will not record the changes till `pauseRecording(false)` is dispatched. Default is `true`.
 
 ### License
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -13,7 +13,8 @@ export const ActionTypes = {
   SET_ACTIONS_ACTIVE: 'SET_ACTIONS_ACTIVE',
   JUMP_TO_STATE: 'JUMP_TO_STATE',
   IMPORT_STATE: 'IMPORT_STATE',
-  LOCK_CHANGES: 'LOCK_CHANGES'
+  LOCK_CHANGES: 'LOCK_CHANGES',
+  PAUSE_RECORDING: 'PAUSE_RECORDING'
 };
 
 /**
@@ -72,6 +73,10 @@ export const ActionCreators = {
 
   lockChanges(status) {
     return { type: ActionTypes.LOCK_CHANGES, status };
+  },
+
+  pauseRecording(status) {
+    return { type: ActionTypes.PAUSE_RECORDING, status };
   }
 };
 
@@ -181,7 +186,8 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
     committedState: initialCommittedState,
     currentStateIndex: 0,
     computedStates: [],
-    dropNewActions: false
+    dropNewActions: false,
+    isPaused: options.shouldRecordChanges === false
   };
 
   /**
@@ -197,7 +203,8 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
       committedState,
       currentStateIndex,
       computedStates,
-      dropNewActions
+      dropNewActions,
+      isPaused
     } = liftedState || initialLiftedState;
 
     if (!liftedState) {
@@ -320,6 +327,24 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           return liftedState || initialLiftedState;
         }
 
+        if (isPaused) {
+          const computedState = computeNextEntry(
+            reducer, liftedAction.action, computedStates[currentStateIndex].state, false
+          );
+          return {
+            monitorState: monitorState,
+            actionsById: { 0: liftAction(INIT_ACTION) },
+            nextActionId: 1,
+            stagedActionIds: [0],
+            skippedActionIds: [],
+            committedState: computedState.state,
+            currentStateIndex: 0,
+            computedStates: [computedState],
+            dropNewActions: false,
+            isPaused: true
+          };
+        }
+
         // Auto-commit as new actions come in.
         if (options.maxAge && stagedActionIds.length === options.maxAge) {
           commitExcessActions(1);
@@ -379,6 +404,11 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
         minInvalidatedStateIndex = Infinity;
         break;
       }
+      case ActionTypes.PAUSE_RECORDING: {
+        isPaused = liftedAction.status;
+        minInvalidatedStateIndex = Infinity;
+        break;
+      }
       case '@@redux/INIT': {
         // Always recompute states on hot reload and init.
         minInvalidatedStateIndex = 0;
@@ -432,7 +462,8 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
       committedState,
       currentStateIndex,
       computedStates,
-      dropNewActions
+      dropNewActions,
+      isPaused
     };
   };
 }

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -662,6 +662,34 @@ describe('instrument', () => {
     });
   });
 
+  describe('Pause recording', () => {
+    it('should pause', () => {
+      expect(store.liftedStore.getState().isPaused).toBe(false);
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.liftedStore.getState().nextActionId).toBe(3);
+      expect(store.getState()).toBe(2);
+
+      store.liftedStore.dispatch({ type: 'PAUSE_RECORDING', status: true });
+      expect(store.liftedStore.getState().isPaused).toBe(true);
+
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.liftedStore.getState().nextActionId).toBe(1);
+      expect(store.liftedStore.getState().actionsById[0].action).toEqual({ type: '@@INIT' });
+      expect(store.getState()).toBe(4);
+
+      store.liftedStore.dispatch({ type: 'PAUSE_RECORDING', status: false });
+      expect(store.liftedStore.getState().isPaused).toBe(false);
+
+      store.dispatch({ type: 'INCREMENT' });
+      store.dispatch({ type: 'INCREMENT' });
+      expect(store.liftedStore.getState().nextActionId).toBe(3);
+      expect(store.liftedStore.getState().actionsById[2].action).toEqual({ type: 'INCREMENT' });
+      expect(store.getState()).toBe(6);
+    });
+  });
+
   it('throws if reducer is not a function', () => {
     expect(() =>
       createStore(undefined, instrument())


### PR DESCRIPTION
This PR allows to pause recording of new actions, not to consume the RAM when it's not necessary. 