### PR TITLE
Support ES6 Symbol as action type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export default function configureStore(initialState) {
     - **pauseActionType** *string* - if specified, whenever `pauseRecording(false)` lifted action is dispatched and there are actions in the history log, will add this action type. If not specified, will commit when paused.
     - **shouldStartLocked** *boolean* - if specified as `true`, it will not allow any non-monitor actions to be dispatched till `lockChanges(false)` is dispatched. Default is `false`.
     - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
+    - **stringifyActionTypes** *boolean* - if set to `true`, will stringify action types to support ES6 Symbols for the monitors and `persistState`. Default to `false`.
 
 ### License
 

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -40,6 +40,14 @@ function doubleCounter(state = 0, action) {
   }
 }
 
+function counterWithSymbols(state = 0, action) {
+  switch (action.type) {
+    case Symbol.for('INCREMENT'): return state + 1;
+    case Symbol.for('DECREMENT'): return state - 1;
+    default: return state;
+  }
+}
+
 function counterWithMultiply(state = 0, action) {
   switch (action.type) {
     case 'INCREMENT': return state + 1;
@@ -417,6 +425,36 @@ describe('instrument', () => {
     expect(reducerCalls).toBe(4);
 
     expect(monitoredLiftedStore.getState().computedStates).toBe(savedComputedStates);
+  });
+
+  it('should support symbols', () => {
+    store = createStore(
+      counterWithSymbols, instrument(undefined, { stringifyActionTypes: false })
+    );
+    const INCREMENT = Symbol.for('INCREMENT');
+    store.dispatch({ type: INCREMENT });
+    store.dispatch({ type: INCREMENT });
+    expect(store.liftedStore.getState().actionsById[1].action.type)
+      .toEqual(Symbol.for('INCREMENT'));
+    expect(store.getState()).toBe(2);
+
+    store.liftedStore.dispatch(ActionCreators.toggleAction(1));
+    expect(store.getState()).toBe(1);
+  });
+
+  it('should stringify symbols', () => {
+    store = createStore(
+      counterWithSymbols, instrument(undefined, { stringifyActionTypes: true })
+    );
+    const INCREMENT = Symbol.for('INCREMENT');
+    store.dispatch({ type: INCREMENT });
+    store.dispatch({ type: INCREMENT });
+    expect(store.liftedStore.getState().actionsById[1].action.type)
+      .toEqual('Symbol(INCREMENT)');
+    expect(store.getState()).toBe(2);
+
+    store.liftedStore.dispatch(ActionCreators.toggleAction(1));
+    expect(store.getState()).toBe(1);
   });
 
   describe('maxAge option', () => {


### PR DESCRIPTION
Add new option: **stringifyActionTypes** *boolean*. If set to `true`, will stringify action types to support ES6 Symbols for the monitors (which don't support them) and for `persistState`. Default to `false`.