### PR TITLE
fix(replaceReducer): Redux ^4.0 replaceReducer action name fix

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -306,7 +306,7 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
     // value whenever we feel like we don't have to recompute the states.
     let minInvalidatedStateIndex = 0;
 
-    if (liftedAction.type.indexOf('@@redux/INIT') === 0) {
+    if (/^@@redux\/(INIT|REPLACE)/.test(liftedAction.type)) {
       if (options.shouldHotReload === false) {
         actionsById = { 0: liftAction(INIT_ACTION) };
         nextActionId = 1;


### PR DESCRIPTION
#### reason:   
in Redux v4, func ```replaceReducer``` use new action ```@@redux/REPLACE``` instead of ```@@redux/INIT```

#### effect: 
in chrome with Redux DevTools, after call ```store.replaceReducer(newReducer)```, new reducer not run
