### PR TITLE
Capture serialized errors/stack traces when actions are dispatched

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -3,6 +3,8 @@ import union from 'lodash/union';
 import isPlainObject from 'lodash/isPlainObject';
 import $$observable from 'symbol-observable';
 
+import {serializeError} from "./serializeError";
+
 export const ActionTypes = {
   PERFORM_ACTION: 'PERFORM_ACTION',
   RESET: 'RESET',
@@ -38,7 +40,7 @@ export const ActionCreators = {
       );
     }
 
-    return { type: ActionTypes.PERFORM_ACTION, action, timestamp: Date.now() };
+    return { type: ActionTypes.PERFORM_ACTION, action, timestamp: Date.now(), stack: serializeError(new Error())};
   },
 
   reset() {

--- a/src/serializeError.js
+++ b/src/serializeError.js
@@ -1,0 +1,57 @@
+// Inlined version of `serializeError` by Sindre Sorhus
+// https://github.com/sindresorhus/serialize-error
+export const serializeError = value => {
+    if (typeof value === 'object') {
+        return destroyCircular(value, []);
+    }
+
+    // People sometimes throw things besides Error objects, so…
+
+    if (typeof value === 'function') {
+        // JSON.stringify discards functions. We do too, unless a function is thrown directly.
+        return `[Function: ${(value.name || 'anonymous')}]`;
+    }
+
+    return value;
+};
+
+// https://www.npmjs.com/package/destroy-circular
+function destroyCircular(from, seen) {
+    const to = Array.isArray(from) ? [] : {};
+
+    seen.push(from);
+
+    for (const key of Object.keys(from)) {
+        const value = from[key];
+
+        if (typeof value === 'function') {
+            continue;
+        }
+
+        if (!value || typeof value !== 'object') {
+            to[key] = value;
+            continue;
+        }
+
+        if (seen.indexOf(from[key]) === -1) {
+            to[key] = destroyCircular(from[key], seen.slice(0));
+            continue;
+        }
+
+        to[key] = '[Circular]';
+    }
+
+    if (typeof from.name === 'string') {
+        to.name = from.name;
+    }
+
+    if (typeof from.message === 'string') {
+        to.message = from.message;
+    }
+
+    if (typeof from.stack === 'string') {
+        to.stack = from.stack;
+    }
+
+    return to;
+}


### PR DESCRIPTION
`performAction()` now creates an `Error` object and serializes it as a field in the lifted action.  This is a prerequisite for displaying stack traces in the DevTools Extension UI.

See https://github.com/zalmoxisus/redux-devtools-extension/issues/429 for the original request.