### PR TITLE
Generate `maxAge` dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default function configureStore(initialState) {
 - arguments
   - **monitorReducer** *function* called whenever an action is dispatched ([see the example of a monitor reducer](https://github.com/gaearon/redux-devtools-log-monitor/blob/master/src/reducers.js#L13)).
   - **options** *object*
-    - **maxAge** *number* - maximum allowed actions to be stored on the history tree, the oldest actions are removed once `maxAge` is reached. 
+    - **maxAge** *number* or *function* - maximum allowed actions to be stored on the history tree, the oldest actions are removed once `maxAge` is reached. Can be generated dynamically with a function getting current action as argument.
     - **shouldCatchErrors** *boolean* - if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
     - **shouldRecordChanges** *boolean* - if specified as `false`, it will not record the changes till `pauseRecording(false)` is dispatched. Default is `true`.
     - **pauseActionType** *string* - if specified, whenever `pauseRecording(false)` lifted action is dispatched and there are actions in the history log, will add this action type. If not specified, will commit when paused.

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -309,6 +309,10 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
     // value whenever we feel like we don't have to recompute the states.
     let minInvalidatedStateIndex = 0;
 
+    // maxAge number can be changed dynamically
+    let maxAge = options.maxAge;
+    if (typeof maxAge === 'function') maxAge = maxAge(liftedAction);
+
     if (/^@@redux\/(INIT|REPLACE)/.test(liftedAction.type)) {
       if (options.shouldHotReload === false) {
         actionsById = { 0: liftAction(INIT_ACTION) };
@@ -324,7 +328,7 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
       // Recompute states on hot reload and init.
       minInvalidatedStateIndex = 0;
 
-      if (options.maxAge && stagedActionIds.length > options.maxAge) {
+      if (maxAge && stagedActionIds.length > maxAge) {
         // States must be recomputed before committing excess.
         computedStates = recomputeStates(
           computedStates,
@@ -337,7 +341,7 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           options.shouldCatchErrors
         );
 
-        commitExcessActions(stagedActionIds.length - options.maxAge);
+        commitExcessActions(stagedActionIds.length - maxAge);
 
         // Avoid double computation.
         minInvalidatedStateIndex = Infinity;
@@ -349,7 +353,7 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           if (isPaused) return computePausedAction();
 
           // Auto-commit as new actions come in.
-          if (options.maxAge && stagedActionIds.length === options.maxAge) {
+          if (maxAge && stagedActionIds.length === maxAge) {
             commitExcessActions(1);
           }
 
@@ -644,9 +648,7 @@ export function unliftStore(liftedStore, liftReducer, options) {
  * Redux instrumentation store enhancer.
  */
 export default function instrument(monitorReducer = () => null, options = {}) {
-  /* eslint-disable no-eq-null */
-  if (options.maxAge != null && options.maxAge < 2) {
-  /* eslint-enable */
+  if (typeof options.maxAge === 'number' && options.maxAge < 2) {
     throw new Error(
       'DevTools.instrument({ maxAge }) option, if specified, ' +
       'may not be less than 2.'

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -353,8 +353,8 @@ export function liftReducerWith(reducer, initialCommittedState, monitorReducer, 
           if (isPaused) return computePausedAction();
 
           // Auto-commit as new actions come in.
-          if (maxAge && stagedActionIds.length === maxAge) {
-            commitExcessActions(1);
+          if (maxAge && stagedActionIds.length >= maxAge) {
+            commitExcessActions(stagedActionIds.length - maxAge + 1);
           }
 
           if (currentStateIndex === stagedActionIds.length - 1) {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -611,7 +611,8 @@ describe('instrument', () => {
     });
 
     it('should use dynamic maxAge', () => {
-      store = createStore(counter, instrument(undefined, { maxAge: () => 3 }));
+      let max = 3;
+      store = createStore(counter, instrument(undefined, { maxAge: () => max }));
 
       store.dispatch({ type: 'INCREMENT' });
       store.dispatch({ type: 'INCREMENT' });
@@ -631,6 +632,38 @@ describe('instrument', () => {
       expect(liftedStoreState.stagedActionIds).toExclude(1);
       expect(liftedStoreState.computedStates[0].state).toBe(1);
       expect(liftedStoreState.committedState).toBe(1);
+      expect(liftedStoreState.currentStateIndex).toBe(2);
+
+      max = 4;
+      store.dispatch({ type: 'INCREMENT' });
+      liftedStoreState = store.liftedStore.getState();
+
+      expect(store.getState()).toBe(4);
+      expect(Object.keys(liftedStoreState.actionsById).length).toBe(4);
+      expect(liftedStoreState.stagedActionIds).toExclude(1);
+      expect(liftedStoreState.computedStates[0].state).toBe(1);
+      expect(liftedStoreState.committedState).toBe(1);
+      expect(liftedStoreState.currentStateIndex).toBe(3);
+
+      max = 3;
+      store.dispatch({ type: 'INCREMENT' });
+      liftedStoreState = store.liftedStore.getState();
+
+      expect(store.getState()).toBe(5);
+      expect(Object.keys(liftedStoreState.actionsById).length).toBe(3);
+      expect(liftedStoreState.stagedActionIds).toExclude(1);
+      expect(liftedStoreState.computedStates[0].state).toBe(3);
+      expect(liftedStoreState.committedState).toBe(3);
+      expect(liftedStoreState.currentStateIndex).toBe(2);
+
+      store.dispatch({ type: 'INCREMENT' });
+      liftedStoreState = store.liftedStore.getState();
+
+      expect(store.getState()).toBe(6);
+      expect(Object.keys(liftedStoreState.actionsById).length).toBe(3);
+      expect(liftedStoreState.stagedActionIds).toExclude(1);
+      expect(liftedStoreState.computedStates[0].state).toBe(4);
+      expect(liftedStoreState.committedState).toBe(4);
       expect(liftedStoreState.currentStateIndex).toBe(2);
     });
 


### PR DESCRIPTION
For cases like https://github.com/zalmoxisus/redux-devtools-extension/issues/316, instead of `maxAge` being constant, we need changing it dynamically.