### PR TITLE
Ability to get stack trace using an outside function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default function configureStore(initialState) {
     - **pauseActionType** *string* - if specified, whenever `pauseRecording(false)` lifted action is dispatched and there are actions in the history log, will add this action type. If not specified, will commit when paused.
     - **shouldStartLocked** *boolean* - if specified as `true`, it will not allow any non-monitor actions to be dispatched till `lockChanges(false)` is dispatched. Default is `false`.
     - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
-    - **shouldIncludeCallstack** *boolean* - if set to `true`, will include callstack for every dispatched action. Default to `false`.
+    - **trace** *boolean* or *function* - if set to `true`, will include stack trace for every dispatched action. You can use a function (with action object as argument) which should return `new Error().stack` string, getting the stack outside of reducers. Default to `false`.
 
 ### License
 

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -710,7 +710,8 @@ describe('instrument', () => {
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
       expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
-      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.js');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -724,8 +725,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
-      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.js');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -741,6 +742,8 @@ describe('instrument', () => {
         exportedState = monitoredLiftedStore.getState();
         expect(exportedState.actionsById[0].stack).toBe(undefined);
         expect(exportedState.actionsById[1].stack).toBeA('string');
+        expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+        expect(exportedState.actionsById[1].stack).toContain('instrument.js');
         expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
         expect(exportedState.actionsById[1].stack).toContain('/mocha/');
         done();

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -743,7 +743,7 @@ describe('instrument', () => {
         expect(exportedState.actionsById[1].stack).toBeA('string');
         expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
         expect(exportedState.actionsById[1].stack).toContain('/mocha/');
-        done()
+        done();
       });
     });
   });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -686,6 +686,68 @@ describe('instrument', () => {
     });
   });
 
+  describe('trace option', () => {
+    let monitoredStore;
+    let monitoredLiftedStore;
+    let exportedState;
+
+    it('should not include stack trace', () => {
+      monitoredStore = createStore(counter, instrument());
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBe(undefined);
+    });
+
+    it('should include stack trace', () => {
+      monitoredStore = createStore(counter, instrument(undefined, { trace: true }));
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBeA('string');
+      expect(exportedState.actionsById[1].stack)
+        .toContain('Error\n    at Error (native)\n    at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+      expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+    });
+
+    it('should get stack trace from a function', () => {
+      const traceFn = () => new Error().stack;
+      monitoredStore = createStore(counter, instrument(undefined, { trace: traceFn }));
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBeA('string');
+      expect(exportedState.actionsById[1].stack)
+        .toContain('Error\n    at traceFn (instrument.spec.js:');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+      expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+    });
+
+    it('should get stack trace inside setTimeout using a function', (done) => {
+      const stack = new Error().stack;
+      setTimeout(() => {
+        const traceFn = () => stack + new Error().stack;
+        monitoredStore = createStore(counter, instrument(undefined, { trace: traceFn }));
+        monitoredLiftedStore = monitoredStore.liftedStore;
+        monitoredStore.dispatch({ type: 'INCREMENT' });
+
+        exportedState = monitoredLiftedStore.getState();
+        expect(exportedState.actionsById[0].stack).toBe(undefined);
+        expect(exportedState.actionsById[1].stack).toBeA('string');
+        expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+        expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+        done()
+      });
+    });
+  });
+
   describe('Import State', () => {
     let monitoredStore;
     let monitoredLiftedStore;
@@ -736,8 +798,8 @@ describe('instrument', () => {
       expect(importMonitoredLiftedStore.getState()).toEqual(expectedImportedState);
     });
 
-    it('should include callstack', () => {
-      let importMonitoredStore = createStore(counter, instrument(undefined, { shouldIncludeCallstack: true }));
+    it('should include stack trace', () => {
+      let importMonitoredStore = createStore(counter, instrument(undefined, { trace: true }));
       let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
 
       importMonitoredStore.dispatch({ type: 'DECREMENT' });
@@ -801,8 +863,8 @@ describe('instrument', () => {
       expect(filterStackAndTimestamps(importMonitoredLiftedStore.getState())).toEqual(exportedState);
     });
 
-    it('should include callstack', () => {
-      let importMonitoredStore = createStore(counter, instrument(undefined, { shouldIncludeCallstack: true }));
+    it('should include stack trace', () => {
+      let importMonitoredStore = createStore(counter, instrument(undefined, { trace: true }));
       let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
 
       importMonitoredStore.dispatch({ type: 'DECREMENT' });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -709,8 +709,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack)
-        .toContain('Error\n    at Error (native)\n    at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -724,8 +724,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack)
-        .toContain('Error\n    at traceFn (instrument.spec.js:');
+      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });


### PR DESCRIPTION
It provides the ability to use something else then `new Error.stack` for providing stack traces, also for some use cases (when using setTimeout, setInterval, events...) stack traces are broken, so it can be composed outside.