### PR TITLE
Limit stack trace frames and exclude instrumentation calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export default function configureStore(initialState) {
     - **shouldStartLocked** *boolean* - if specified as `true`, it will not allow any non-monitor actions to be dispatched till `lockChanges(false)` is dispatched. Default is `false`.
     - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
     - **trace** *boolean* or *function* - if set to `true`, will include stack trace for every dispatched action. You can use a function (with action object as argument) which should return `new Error().stack` string, getting the stack outside of reducers. Default to `false`.
+    - **traceLimit** *number* - maximum stack trace frames to be stored (in case `trace` option was provided as `true`). By default it's `10`. Note that for Chrome there's a global limit to `10`, so you should also override the global `Error.stackTraceLimit` for more. If `trace` option is a function, `traceLimit` will have no effect, that should be handled there like so: `trace: () => new Error().stack.split('\n').slice(0, limit+1).join('\n')`. There's `+1` for `Error\n`.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export default function configureStore(initialState) {
     - **pauseActionType** *string* - if specified, whenever `pauseRecording(false)` lifted action is dispatched and there are actions in the history log, will add this action type. If not specified, will commit when paused.
     - **shouldStartLocked** *boolean* - if specified as `true`, it will not allow any non-monitor actions to be dispatched till `lockChanges(false)` is dispatched. Default is `false`.
     - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
-    - **shouldIncludeCallstack** *boolean* - if set to `true`, will include callstack for every dispatched action. Default to `false`.
+    - **trace** *boolean* or *function* - if set to `true`, will include stack trace for every dispatched action. You can use a function (with action object as argument) which should return `new Error().stack` string, getting the stack outside of reducers. Default to `false`.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Redux DevTools Instrumentation
 ==============================
 
-Redux enhancer used along with [Redux DevTools](https://github.com/gaearon/redux-devtools) or [Remote Redux DevTools](https://github.com/zalmoxisus/remote-redux-devtools).
+Redux enhancer used along with [Redux DevTools](https://github.com/reduxjs/redux-devtools) or [Remote Redux DevTools](https://github.com/zalmoxisus/remote-redux-devtools).
 
 ### Installation
 
@@ -51,7 +51,7 @@ export default function configureStore(initialState) {
     - **shouldStartLocked** *boolean* - if specified as `true`, it will not allow any non-monitor actions to be dispatched till `lockChanges(false)` is dispatched. Default is `false`.
     - **shouldHotReload** *boolean* - if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Default to `true`.
     - **trace** *boolean* or *function* - if set to `true`, will include stack trace for every dispatched action. You can use a function (with action object as argument) which should return `new Error().stack` string, getting the stack outside of reducers. Default to `false`.
-    - **traceLimit** *number* - maximum stack trace frames to be stored (in case `trace` option was provided as `true`). By default it's `10`. Note that for Chrome there's a global limit to `10`, so you should also override the global `Error.stackTraceLimit` for more. If `trace` option is a function, `traceLimit` will have no effect, that should be handled there like so: `trace: () => new Error().stack.split('\n').slice(0, limit+1).join('\n')`. There's `+1` for `Error\n`.
+    - **traceLimit** *number* - maximum stack trace frames to be stored (in case `trace` option was provided as `true`). By default it's `10`. If `trace` option is a function, `traceLimit` will have no effect, that should be handled there like so: `trace: () => new Error().stack.split('\n').slice(0, limit+1).join('\n')` (`+1` is needed for Chrome where's an extra 1st frame for `Error\n`).
 
 ### License
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -620,15 +620,17 @@ export function unliftStore(liftedStore, liftReducer, options) {
     return lastDefinedState;
   }
 
+  function dispatch(action) {
+    liftedStore.dispatch(liftAction(action, trace, traceLimit, dispatch));
+    return action;
+  }
+
   return {
     ...liftedStore,
 
     liftedStore,
 
-    dispatch(action) {
-      liftedStore.dispatch(liftAction(action, trace, traceLimit, this.dispatch));
-      return action;
-    },
+    dispatch,
 
     getState,
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -40,6 +40,7 @@ export const ActionCreators = {
 
     let stack;
     if (trace) {
+      let extraFrames = 0;
       if (typeof trace === 'function') {
         stack = trace(action);
       } else {
@@ -51,13 +52,15 @@ export const ActionCreators = {
             Error.stackTraceLimit = traceLimit;
           }
           Error.captureStackTrace(error, toExcludeFromTrace);
+        } else {
+          extraFrames = 3;
         }
         stack = error.stack;
         if (prevStackTraceLimit) Error.stackTraceLimit = prevStackTraceLimit;
-        if (typeof Error.stackTraceLimit !== 'number' || Error.stackTraceLimit > traceLimit) {
+        if (extraFrames || typeof Error.stackTraceLimit !== 'number' || Error.stackTraceLimit > traceLimit) {
           const frames = stack.split('\n');
           if (frames.length > traceLimit) {
-            stack = frames.slice(0, traceLimit + (frames[0] === 'Error' ? 1 : 0)).join('\n');
+            stack = frames.slice(0, traceLimit + extraFrames + (frames[0] === 'Error' ? 1 : 0)).join('\n');
           }
         }
       }

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -39,18 +39,26 @@ export const ActionCreators = {
     }
 
     let stack;
-    let error;
-    let frames;
     if (trace) {
-      if (typeof trace === 'function') stack = trace(action);
-      else {
-        error = Error();
-        // https://v8.dev/docs/stack-trace-api#stack-trace-collection-for-custom-exceptions
-        if (Error.captureStackTrace) Error.captureStackTrace(error, toExcludeFromTrace);
+      if (typeof trace === 'function') {
+        stack = trace(action);
+      } else {
+        const error = Error();
+        let prevStackTraceLimit;
+        if (Error.captureStackTrace) {
+          if (Error.stackTraceLimit < traceLimit) {
+            prevStackTraceLimit = Error.stackTraceLimit;
+            Error.stackTraceLimit = traceLimit;
+          }
+          Error.captureStackTrace(error, toExcludeFromTrace);
+        }
         stack = error.stack;
+        if (prevStackTraceLimit) Error.stackTraceLimit = prevStackTraceLimit;
         if (typeof Error.stackTraceLimit !== 'number' || Error.stackTraceLimit > traceLimit) {
-          frames = stack.split('\n');
-          if (frames.length > traceLimit) stack = frames.slice(0, traceLimit + 1).join('\n'); // +1 for `Error\n`
+          const frames = stack.split('\n');
+          if (frames.length > traceLimit) {
+            stack = frames.slice(0, traceLimit + (frames[0] === 'Error' ? 1 : 0)).join('\n');
+          }
         }
       }
     }

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -710,8 +710,7 @@ describe('instrument', () => {
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
       expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
-      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
-      expect(exportedState.actionsById[1].stack).toContain('instrument.js');
+      expect(exportedState.actionsById[1].stack).toNotMatch(/instrument.js/);
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -710,7 +710,8 @@ describe('instrument', () => {
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
       expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
-      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.js');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -724,8 +725,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
-      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.js');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -741,6 +742,8 @@ describe('instrument', () => {
         exportedState = monitoredLiftedStore.getState();
         expect(exportedState.actionsById[0].stack).toBe(undefined);
         expect(exportedState.actionsById[1].stack).toBeA('string');
+        expect(exportedState.actionsById[1].stack).toContain('at Object.performAction');
+        expect(exportedState.actionsById[1].stack).toContain('instrument.js');
         expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
         expect(exportedState.actionsById[1].stack).toContain('/mocha/');
         done();

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -743,7 +743,7 @@ describe('instrument', () => {
         expect(exportedState.actionsById[1].stack).toBeA('string');
         expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
         expect(exportedState.actionsById[1].stack).toContain('/mocha/');
-        done()
+        done();
       });
     });
   });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -686,6 +686,68 @@ describe('instrument', () => {
     });
   });
 
+  describe('trace option', () => {
+    let monitoredStore;
+    let monitoredLiftedStore;
+    let exportedState;
+
+    it('should not include stack trace', () => {
+      monitoredStore = createStore(counter, instrument());
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBe(undefined);
+    });
+
+    it('should include stack trace', () => {
+      monitoredStore = createStore(counter, instrument(undefined, { trace: true }));
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBeA('string');
+      expect(exportedState.actionsById[1].stack)
+        .toContain('Error\n    at Error (native)\n    at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+      expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+    });
+
+    it('should get stack trace from a function', () => {
+      const traceFn = () => new Error().stack;
+      monitoredStore = createStore(counter, instrument(undefined, { trace: traceFn }));
+      monitoredLiftedStore = monitoredStore.liftedStore;
+      monitoredStore.dispatch({ type: 'INCREMENT' });
+
+      exportedState = monitoredLiftedStore.getState();
+      expect(exportedState.actionsById[0].stack).toBe(undefined);
+      expect(exportedState.actionsById[1].stack).toBeA('string');
+      expect(exportedState.actionsById[1].stack)
+        .toContain('Error\n    at traceFn (instrument.spec.js:');
+      expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+      expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+    });
+
+    it('should get stack trace inside setTimeout using a function', (done) => {
+      const stack = new Error().stack;
+      setTimeout(() => {
+        const traceFn = () => stack + new Error().stack;
+        monitoredStore = createStore(counter, instrument(undefined, { trace: traceFn }));
+        monitoredLiftedStore = monitoredStore.liftedStore;
+        monitoredStore.dispatch({ type: 'INCREMENT' });
+
+        exportedState = monitoredLiftedStore.getState();
+        expect(exportedState.actionsById[0].stack).toBe(undefined);
+        expect(exportedState.actionsById[1].stack).toBeA('string');
+        expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
+        expect(exportedState.actionsById[1].stack).toContain('/mocha/');
+        done()
+      });
+    });
+  });
+
   describe('Import State', () => {
     let monitoredStore;
     let monitoredLiftedStore;
@@ -736,8 +798,8 @@ describe('instrument', () => {
       expect(importMonitoredLiftedStore.getState()).toEqual(expectedImportedState);
     });
 
-    it('should include callstack', () => {
-      let importMonitoredStore = createStore(counter, instrument(undefined, { shouldIncludeCallstack: true }));
+    it('should include stack trace', () => {
+      let importMonitoredStore = createStore(counter, instrument(undefined, { trace: true }));
       let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
 
       importMonitoredStore.dispatch({ type: 'DECREMENT' });
@@ -801,8 +863,8 @@ describe('instrument', () => {
       expect(filterStackAndTimestamps(importMonitoredLiftedStore.getState())).toEqual(exportedState);
     });
 
-    it('should include callstack', () => {
-      let importMonitoredStore = createStore(counter, instrument(undefined, { shouldIncludeCallstack: true }));
+    it('should include stack trace', () => {
+      let importMonitoredStore = createStore(counter, instrument(undefined, { trace: true }));
       let importMonitoredLiftedStore = importMonitoredStore.liftedStore;
 
       importMonitoredStore.dispatch({ type: 'DECREMENT' });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -709,8 +709,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack)
-        .toContain('Error\n    at Error (native)\n    at Object.performAction (instrument.js:');
+      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });
@@ -724,8 +724,8 @@ describe('instrument', () => {
       exportedState = monitoredLiftedStore.getState();
       expect(exportedState.actionsById[0].stack).toBe(undefined);
       expect(exportedState.actionsById[1].stack).toBeA('string');
-      expect(exportedState.actionsById[1].stack)
-        .toContain('Error\n    at traceFn (instrument.spec.js:');
+      expect(exportedState.actionsById[1].stack).toMatch(/^Error/);
+      expect(exportedState.actionsById[1].stack).toContain('at Object.performAction (instrument.js:');
       expect(exportedState.actionsById[1].stack).toContain('instrument.spec.js');
       expect(exportedState.actionsById[1].stack).toContain('/mocha/');
     });


### PR DESCRIPTION
There could appear a problem with consumed memory and serializing large stacks. For Chrome call stack is limited by default to 10. It doesn't include 3 our calls, which we're filtering with `Error.captureStackTrace`, so it should be enough. That can be changed with `Error.stackTraceLimit = limit` (some libraries could do that and cause issues). For Firefox the limit is [hardcoded](https://dxr.mozilla.org/mozilla-beta/source/js/src/jsexn.cpp#314) to 128 stack frames and it's unlimited in Safari. So we need to limit it.
